### PR TITLE
It didn't work when I installed the plugin, and I went in to fix some minor problems.

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -37,7 +37,7 @@ class auth_plugin_authnc extends DokuWiki_Auth_Plugin
             CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
             CURLOPT_TCP_FASTOPEN => 1,
             CURLOPT_HTTPHEADER => array("OCS-APIRequest:true"),
-            CURLOPT_RESOLVE => array($this->con), // Optimize requests by pre-resolving the address.
+            //CURLOPT_RESOLVE => array($this->con), // Optimize requests by pre-resolving the address.
         );
         curl_setopt_array($this->curl, $options);
 
@@ -84,13 +84,13 @@ class auth_plugin_authnc extends DokuWiki_Auth_Plugin
         global $USERINFO;
         $sticky ? $sticky = true : $sticky = false; //sanity check
 
+        $logged_in = false;
         // check only if a user tries to log in, otherwise the function is called with every pageload
         if (!empty($user)) {
 
             // try the login
             $server = $this->con . 'users/' . $user;
             $xml = $this->nc_request($server, $user, $pass);
-            $logged_in = false;
 
             if ($xml && $xml->meta->status == "ok") {
                 // hurray, we're succeded


### PR DESCRIPTION
Commented out CURLOPT_RESOLVE, it's in the constructor and $con wasn't set beforehand so it just didn't work.
Moved $logged_in out into a broader scope in trustExternal, so returning it actually works.

It works for me now. oh well. I'm not a PHP dev, but I was annoyed that it didn't work and it seemed doable.
Also this was on PHP 8.3, if that matters.